### PR TITLE
feat!: inline sources in published style

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "mapeo-offline-map",
   "version": "2.0.0",
   "description": "Fallback offline map data and styles for Mapeo",
-  "main": "style.json",
+  "main": "dist/style.json",
   "scripts": {
     "start": "budo --dir preview/ preview/index.js --live --open",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "make clean && make all"
+    "build": "make clean && make all",
+    "prepack": "npm run build"
   },
   "keywords": [
     "mapeo"
@@ -18,7 +19,7 @@
     "budo": "^11.6.4"
   },
   "files": [
-    "dist/*"
+    "dist"
   ],
   "dependencies": {},
   "repository": {

--- a/preview/index.js
+++ b/preview/index.js
@@ -1,46 +1,7 @@
 /* global mapboxgl */
-var style = require('../style.json')
+var style = require('../dist/style.json')
 
-var sources = [
-  {
-    id: 'boundaries-source',
-    data: require('../dist/boundaries.json')
-  },
-  {
-    id: 'lakes-source',
-    data: require('../dist/lakes.json')
-  },
-  {
-    id: 'land-source',
-    data: require('../dist/land.json')
-  },
-  {
-    id: 'rivers-source',
-    data: require('../dist/rivers.json')
-  },
-  {
-    id: 'graticule-source',
-    data: require('../dist/graticule.json')
-  }
-]
-
-mapboxgl.accessToken =
-  'pk.eyJ1IjoiZGlnaWRlbSIsImEiOiJuM3FabmNFIn0._gF6262MSzePWUChu4S9PA'
-var map = (window.map = new mapboxgl.Map({
+new mapboxgl.Map({
   container: 'map',
-  style: {
-    version: 8,
-    name: 'Empty',
-    sources: {},
-    layers: []
-  }
-}))
-
-map.on('load', function () {
-  for (const { id, data } of sources) {
-    map.addSource(id, { type: 'geojson', data: data })
-  }
-  for (const layer of style.layers) {
-    map.addLayer(layer)
-  }
+  style
 })

--- a/style-no-sources.json
+++ b/style-no-sources.json
@@ -20,7 +20,7 @@
         "fill-color": "#ece1cb"
       },
       "layout": {},
-      "source": "land-source",
+      "source": "land",
       "id": "land"
     },
     {
@@ -42,7 +42,7 @@
         "line-join": "round",
         "line-cap": "round"
       },
-      "source": "rivers-source",
+      "source": "rivers",
       "id": "rivers"
     },
     {
@@ -51,11 +51,11 @@
         "fill-color": "#78bced"
       },
       "layout": {},
-      "source": "lakes-source",
+      "source": "lakes",
       "id": "lakes"
     },
     {
-      "source": "boundaries-source",
+      "source": "boundaries",
       "type": "line",
       "paint": {
         "line-color": [
@@ -77,7 +77,7 @@
       "id": "boundaries-bg"
     },
     {
-      "source": "boundaries-source",
+      "source": "boundaries",
       "type": "line",
       "paint": {
         "line-color": "#828282",
@@ -90,7 +90,7 @@
       "id": "boundaries-dd"
     },
     {
-      "source": "graticule-source",
+      "source": "graticule",
       "type": "line",
       "paint": {
         "line-color": "hsl(0, 100%, 0%)",
@@ -112,7 +112,7 @@
       "layout": {},
       "filter": ["match", ["get", "interval"], ["1"], true, false],
       "type": "line",
-      "source": "graticule-source",
+      "source": "graticule",
       "id": "graticule-1",
       "paint": {
         "line-color": "hsl(0, 0%, 0%)",
@@ -144,7 +144,7 @@
       "layout": {},
       "filter": ["match", ["get", "interval"], ["0.1"], true, false],
       "type": "line",
-      "source": "graticule-source",
+      "source": "graticule",
       "id": "graticule-0.1",
       "paint": {
         "line-color": "hsl(0, 0%, 0%)",


### PR DESCRIPTION
This change inlines all the sources into a single published style.json, which should be the only file that is needed to serve this style offline.

Also removes unnecessary mapbox token from preview code.

Plus a fix for a change to the natural earth downloads URL